### PR TITLE
Add After=suspend.target

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ When using [systemd](http://freedesktop.org/wiki/Software/systemd/), you can use
 Description=Lock X session using sxlock on hibernation/suspension
 After=suspend.target
 
-
 [Service]
 User=<username>
 Environment=DISPLAY=:0


### PR DESCRIPTION
This fixes some compatibility issues on resume with other application. Thus it is better to run sxlock after the suspend.target.
