### PR TITLE
do include the last element of the outputs array

### DIFF
--- a/sxlock.c
+++ b/sxlock.c
@@ -371,7 +371,7 @@ main(int argc, char** argv) {
             XRRFreeOutputInfo(output_info);
             output_info = XRRGetOutputInfo(dpy, screen, screen->outputs[i++]);
             fprintf(stderr, "Warning: no primary output detected, trying %s.\n", output_info->name);
-            if (i == screen->noutput)
+            if (i == screen->noutput + 1)
                 die("error: no connected output detected.\n");
         }
 


### PR DESCRIPTION
I think there was a bug; the program was exiting from the loop prematurely, discarding the last element of the array of display outputs. Please consider my proposed correction.