### PR TITLE
Make systemd unit take user as instance identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For manual installation just install dependencies, checkout and make:
 Hooking into systemd events
 ---------------------------
 
-When using [systemd](http://freedesktop.org/wiki/Software/systemd/), you can use the following service (create `/etc/systemd/system/sxlock.service`) to let the system lock your X session on hibernation or suspend:
+When using [systemd](http://freedesktop.org/wiki/Software/systemd/), you can use the following service (create `/etc/systemd/system/sxlock@.service`) to let the system lock your X session on hibernation or suspend:
 
 ```ini
 [Unit]
@@ -47,7 +47,7 @@ Description=Lock X session using sxlock
 Before=sleep.target
 
 [Service]
-User=<username>
+User=%i
 Environment=DISPLAY=:0
 ExecStart=/usr/bin/sxlock
 
@@ -55,4 +55,9 @@ ExecStart=/usr/bin/sxlock
 WantedBy=sleep.target
 ```
 
-However, this approach is useful only for single-user systems, because there is no way to know which user is currently logged in. Use [xss-lock](https://bitbucket.org/raymonad/xss-lock) as an alternative for multi-user systems.
+Enable service for your user with:
+    
+    `# systemctl enable sxlock@<username>`
+
+
+This approach, however, is useful only for single-user systems, because there is no way to know which user is currently logged in. Use [xss-lock](https://bitbucket.org/raymonad/xss-lock) as an alternative for multi-user systems.


### PR DESCRIPTION
Thanks for great `slock` fork!

When setting up I didn't like too much to set my username in the unit file as I use my dot-files across multiple machines where the username is not necessarily the same. I therefore opted to give username as `sxlock@markus.service`, when using the service.

In practice:

    # systemctl enable sxlock        # before
    # systemctl enable sxlock@markus # after

This has one **drawback**, and that is that if people are on a multi-user system, for instance, they can start several instances of the unit for different users.

Anyways, I thought I would suggest the change. Feel free to close without merge if you think it's an anti-feature.

Cheers!

## References
 - See [Arch wiki](https://wiki.archlinux.org/index.php/systemd#Using_units) for more info the syntax of instance identifiers (`unit@.service`).