### PR TITLE
Use XRRGetScreenResourcesCurrent to avoid polling

### DIFF
--- a/sxlock.c
+++ b/sxlock.c
@@ -386,7 +386,7 @@ main(int argc, char** argv) {
         XRROutputInfo* output_info = NULL;
         XRRCrtcInfo* crtc_info = NULL;
 
-        screen = XRRGetScreenResources (dpy, root);
+        screen = XRRGetScreenResourcesCurrent (dpy, root);
         output = XRRGetOutputPrimary(dpy, root);
 
         /* When there is no primary output, the return value of XRRGetOutputPrimary


### PR DESCRIPTION
XRRGetScreenResources is too slow due to polling. See
https://lists.freedesktop.org/archives/xorg/2008-May/035007.html for
instance. It appears there was a solution made for this to use only
cached resources: XRRGetScreenResourcesCurrent. See
https://github.com/jcs/xdimmer/commit/70513f5cfb9273730fcc11258d3ccb73cab6b32f
for another instance of using this fix.